### PR TITLE
Add exception handler to power-on action.

### DIFF
--- a/bt_helper.py
+++ b/bt_helper.py
@@ -1,7 +1,6 @@
 import dbus
 import dbus.mainloop.glib
 import sys
-import time
 import logging
 import time
 from gi.repository import GObject
@@ -93,8 +92,11 @@ class BtAdapter():
         if powered:
             logger.info('Device already powered')
             return
-        self.set_bool_prop('Powered', True)
-        logger.info('Powered on')
+        try:
+            self.set_bool_prop('Powered', True)
+            logger.info('Powered on')
+        except Exception as exc:
+            logging.error('Failed to power on - {}'.format(exc.get_dbus_message()))
 
 def properties_changed(interface, changed, invalidated, path):
     logger.info('Property changed for device @ %s. Change: %s', path, changed)


### PR DESCRIPTION
Add an exception handler to deal with those unexpected situations when powering on a device, e.g. device blocked.

For blocked devices, we can even use rfkill unblock all to unblock them.
